### PR TITLE
Refactoring

### DIFF
--- a/lib/area.coffee
+++ b/lib/area.coffee
@@ -1,6 +1,7 @@
 {opposite} = require './utils'
 {inspect} = require 'util'
 
+module.exports =
 class Area
   data: null
   linewise: false
@@ -43,7 +44,7 @@ class Area
         text = @overwrittenArea.pushOut(text, opposite(direction)) if @overwrittenArea?
         @data[0] = [text, other...].join("")
       when 'left'
-        [text, other...,] = @data[0]
+        [text, other...] = @data[0]
         text = @overwrittenArea.pushOut(text, opposite(direction)) if @overwrittenArea?
         @data[0] = [other..., text].join("")
 
@@ -69,5 +70,3 @@ class Area
         pushedOut = data.pop()
         @data[0] = data.join("")
         pushedOut
-
-module.exports = Area

--- a/lib/move-selected-text.coffee
+++ b/lib/move-selected-text.coffee
@@ -9,7 +9,7 @@ _ = require 'underscore-plus'
 {inspect} = require 'util'
 Area = require './area'
 
-{pointIsAtEndOfLine, sortRanges} = requireFrom('vim-mode-plus', 'utils')
+{pointIsAtEndOfLine} = requireFrom('vim-mode-plus', 'utils')
 swrap = requireFrom('vim-mode-plus', 'selection-wrapper')
 BlockwiseSelection = requireFrom('vim-mode-plus', 'blockwise-selection')
 Base = requireFrom('vim-mode-plus', 'base')
@@ -146,7 +146,7 @@ class MoveSelectedTextUp extends MoveSelectedText
       selections = @editor.getSelectionsOrderedByBufferPosition()
       selections.reverse() if @direction is 'down'
       @editor.transact =>
-        @countTimes =>
+        @countTimes @getCount(), =>
           for selection in selections
             if @isLinewise()
               @moveLinewise(selection)

--- a/lib/move-selected-text.coffee
+++ b/lib/move-selected-text.coffee
@@ -20,6 +20,29 @@ StateManager = require './state-manager'
 stateManager = new StateManager()
 disposableByEditor = new Map
 
+# UndoJoin
+#
+# Move
+# - overwrite: true
+#   - linewise: rotateRows
+#   - characterwise:
+#     if multiRowSelection, behave as linewise
+#   - blockwise
+# - overwrite: false
+#   - linewise
+#   - characterwise
+#   - blockwise
+#
+# Duplicate
+# - overwrite: true
+#   - linewise
+#   - characterwise
+#   - blockwise
+# - overwrite: false
+#   - linewise
+#   - characterwise
+#   - blockwise
+#
 # Move
 # -------------------------
 class MoveSelectedText extends Operator

--- a/lib/move-selected-text.coffee
+++ b/lib/move-selected-text.coffee
@@ -243,6 +243,9 @@ class DuplicateSelectedTextUp extends DuplicateSelectedText
       @vimState.activate('visual', 'characterwise')
 
   execute: ->
+    if @isLinewise() or @direction in ['right', 'left']
+      return super
+
     @editor.transact =>
       return if (count = @getCount()) is 0
       @withBlockwise =>

--- a/lib/state-manager.coffee
+++ b/lib/state-manager.coffee
@@ -1,0 +1,44 @@
+{
+  getSelectedTexts
+} = require './utils'
+
+class State
+  selectedTexts: null
+  checkpoint: null
+  overwrittenBySelection: null
+  editor: null
+
+  constructor: (@editor) ->
+
+  isSequential: ->
+    @selectedTexts is getSelectedTexts(@editor)
+
+  init: ->
+    @checkpoint = @editor.createCheckpoint()
+    @overwrittenBySelection = null
+
+  updateSelectedTexts: ->
+    @selectedTexts = getSelectedTexts(@editor)
+
+  groupChanges: ->
+    unless @checkpoint?
+      throw new Error("called GroupChanges with @checkpoint undefined")
+    @editor.groupChangesSinceCheckpoint(@checkpoint)
+
+class StateManager
+  constructor: ->
+    @stateByEditor = new Map
+
+  set: (editor) ->
+    @stateByEditor.set(editor, new State(editor))
+
+  get: (editor) ->
+    @stateByEditor.get(editor)
+
+  has: (editor) ->
+    @stateByEditor.has(editor)
+
+  remove: (editor) ->
+    @stateByEditor.delete(editor)
+
+module.exports = StateManager

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -41,10 +41,12 @@ pop = (list, num) ->
 
 # Return function to restore
 switchToLinewise = (selection) ->
-  swrap(selection).preserveCharacterwise()
-  swrap(selection).expandOverLine(preserveGoalColumn: true)
+  selection = swrap(selection)
+  selection.saveProperties()
+  selection.applyWise('linewise')
   new Disposable ->
-    swrap(selection).restoreCharacterwise()
+    selection.normalize()
+    selection.applyWise('characterwise')
 
 opposite = (direction) ->
   switch direction

--- a/spec/vim-mode-plus-move-selected-text-spec.coffee
+++ b/spec/vim-mode-plus-move-selected-text-spec.coffee
@@ -13,6 +13,9 @@ toggleOverwrite = (target) ->
 getOverwriteConfig = ->
   atom.config.get('vim-mode-plus-move-selected-text.overwrite')
 
+setOverwriteConfig = (value) ->
+  atom.config.set('vim-mode-plus-move-selected-text.overwrite', value)
+
 {getVimState, TextData, dispatch} = requireFrom 'vim-mode-plus', 'spec/spec-helper'
 
 # Should cover
@@ -57,56 +60,73 @@ describe "vim-mode-plus-move-selected-text", ->
       atom.packages.activatePackage('vim-mode-plus-move-selected-text')
 
   describe "overwrite config", ->
-    [vimState1, vimState2, vimState3] = []
+    [vimState1, vimState2, vimState3, vimState4, allVimState] = []
+    ensureOverwriteClassForVimStates = (vimStates, bool) ->
+      for _vimState in vimStates
+        ensureOverwriteClass(_vimState.editorElement, bool)
+
+    ensureOverwriteClassInSyncForVimStates = (vimStates) ->
+      ensureOverwriteClassForVimStates(vimStates, getOverwriteConfig())
 
     beforeEach ->
       getVimState "sample1", (state, vim) -> vimState1 = state
       getVimState "sample2", (state, vim) -> vimState2 = state
 
-    it "toggle command toggle overwrite config value", ->
-      expect(getOverwriteConfig()).toBe(false)
+      runs ->
+        allVimState = []
+        allVimState.push(vimState1, vimState2)
 
-      toggleOverwrite(editorElement)
-      expect(getOverwriteConfig()).toBe(true)
+    describe "basic behavior of 'move-selected-text-toggle-overwrite'", ->
+      it "toggle command toggle 'overwrite' config value", ->
+        expect(getOverwriteConfig()).toBe(false)
+        toggleOverwrite(editorElement)
+        expect(getOverwriteConfig()).toBe(true)
 
-      toggleOverwrite(editorElement)
-      expect(getOverwriteConfig()).toBe(false)
+        toggleOverwrite(editorElement)
+        expect(getOverwriteConfig()).toBe(false)
 
     describe "when overwrite config is toggled in false -> true -> false", ->
       it "add/remove overwrite css class to/from all editorElement including newly created editor", ->
         runs ->
-          # ensureOverwrite
           expect(getOverwriteConfig()).toBe(false)
-          ensureOverwriteClass(el, false) for {editorElement: el} in [vimState1, vimState2]
+          ensureOverwriteClassInSyncForVimStates(allVimState)
 
           toggleOverwrite(vimState1.editorElement)
           expect(getOverwriteConfig()).toBe(true)
-          ensureOverwriteClass(el, true) for {editorElement: el} in [vimState1, vimState2]
+          ensureOverwriteClassInSyncForVimStates(allVimState)
 
-        getVimState "sample3", (state, vim) ->
-          vimState3 = state
-          ensureOverwriteClass(state.editorElement, true)
+        getVimState "sample3", (state, vim) -> allVimState.push(state)
 
         runs ->
+          expect(allVimState).toHaveLength(3)
+          ensureOverwriteClassInSyncForVimStates(allVimState)
+
           toggleOverwrite(vimState1.editorElement)
           expect(getOverwriteConfig()).toBe(false)
-          ensureOverwriteClass(el, false) for {editorElement: el} in [vimState1, vimState2, vimState3]
+          ensureOverwriteClassInSyncForVimStates(allVimState)
 
-        waitsForPromise ->
-          atom.packages.activatePackage('vim-mode-plus-move-selected-text')
+        getVimState "sample4", (state, vim) -> allVimState.push(state)
 
-    describe "deactivate", ->
+        runs ->
+          expect(allVimState).toHaveLength(4)
+          ensureOverwriteClassInSyncForVimStates(allVimState)
+          toggleOverwrite(vimState1.editorElement)
+          expect(getOverwriteConfig()).toBe(true)
+          ensureOverwriteClassInSyncForVimStates(allVimState)
+
+    describe "when deactivate", ->
       beforeEach ->
         getVimState "sample3", (state, vim) -> vimState3 = state
 
+        runs ->
+          allVimState.push(vimState3)
+
       it "remove overwrite css class from all editorElement", ->
         toggleOverwrite(vimState1.editorElement)
-        els = (state.editorElement for state in [vimState1, vimState2, vimState3])
-        els.push(editorElement)
-        ensureOverwriteClass(el, true) for el in els
-
+        expect(allVimState).toHaveLength(3)
+        ensureOverwriteClassForVimStates(allVimState, true)
         atom.packages.deactivatePackage('vim-mode-plus-move-selected-text')
-        ensureOverwriteClass(el, false) for el in els
+        ensureOverwriteClassForVimStates(allVimState, false)
 
   describe "move up/down", ->
     textData = null
@@ -122,103 +142,111 @@ describe "vim-mode-plus-move-selected-text", ->
         cursor: [0, 0]
 
     describe "linewise", ->
-      lines = (lines...) -> text.getLines(lines)
-      getEnsurerForLinewiseMove = (textData, {selectedText, selectionIsReversed}) ->
-        (keystroke, {rows, text}) ->
-          if (not text?) and rows?
-            text = textData.getLines(rows)
-          ensure keystroke, {text, selectedText, selectionIsReversed}
+      describe "overwrite: false", ->
+        lines = (lines...) -> text.getLines(lines)
+        getEnsurerForLinewiseMove = (textData, {selectedText, selectionIsReversed}) ->
+          (keystroke, {rows, text}) ->
+            if (not text?) and rows?
+              text = textData.getLines(rows)
+            ensure keystroke, {text, selectedText, selectionIsReversed}
 
-      it "[case-1] one line", ->
-        ensureLinewiseMove = getEnsurerForLinewiseMove textData,
-          selectedText: "line0\n", selectionIsReversed: false
-        ensureLinewiseMove 'V', rows: [0, 1, 2]
-        ensureLinewiseMove 'ctrl-j', rows: [1, 0, 2]
-        ensureLinewiseMove 'ctrl-j', rows: [1, 2, 0]
-        ensureLinewiseMove 'ctrl-k', rows: [1, 0, 2]
-        ensureLinewiseMove 'ctrl-k', rows: [0, 1, 2]
-      it "[case-2] two line", ->
-        ensureLinewiseMove = getEnsurerForLinewiseMove textData,
-          selectedText: "line0\nline1\n", selectionIsReversed: false
-        ensureLinewiseMove 'V j', rows: [0, 1, 2]
-        ensureLinewiseMove 'ctrl-j', rows: [2, 0, 1]
-        ensureLinewiseMove 'ctrl-k', rows: [0, 1, 2]
-      it "[case-3] two line, selection is reversed: keep reversed state", ->
-        ensureLinewiseMove = getEnsurerForLinewiseMove textData,
-          selectedText: "line0\nline1\n", selectionIsReversed: true
-        set cursor: [1, 0]
-        ensureLinewiseMove 'V k', rows: [0, 1, 2]
-        ensureLinewiseMove 'ctrl-j', rows: [2, 0, 1]
-        ensureLinewiseMove 'ctrl-k', rows: [0, 1, 2]
-      it "extends final row when move down", ->
-        ensureLinewiseMove = getEnsurerForLinewiseMove textData,
-          selectedText: "line2\n", selectionIsReversed: false
-        set cursor: [2, 0]
-        ensureLinewiseMove 'V', rows: [0, 1, 2]
-        ensureLinewiseMove 'ctrl-j', text: [
-          "line0"
-          "line1"
-          ""
-          "line2"
-          ""
-        ].join("\n")
-        ensureLinewiseMove 'ctrl-j', text: [
-          "line0"
-          "line1"
-          ""
-          ""
-          "line2"
-          ""
-        ].join("\n")
-      it "support count", ->
-        ensureLinewiseMove = getEnsurerForLinewiseMove textData,
-          selectedText: "line0\n", selectionIsReversed: false
-        ensureLinewiseMove 'V', rows: [0, 1, 2]
-        ensureLinewiseMove '2 ctrl-j', rows: [1, 2, 0]
-        ensureLinewiseMove '2 ctrl-k', rows: [0, 1, 2]
+        it "[case-1] one line", ->
+          ensureLinewiseMove = getEnsurerForLinewiseMove textData,
+            selectedText: "line0\n", selectionIsReversed: false
+          ensureLinewiseMove 'V', rows: [0, 1, 2]
+          ensureLinewiseMove 'ctrl-j', rows: [1, 0, 2]
+          ensureLinewiseMove 'ctrl-j', rows: [1, 2, 0]
+          ensureLinewiseMove 'ctrl-k', rows: [1, 0, 2]
+          ensureLinewiseMove 'ctrl-k', rows: [0, 1, 2]
+        it "[case-2] two line", ->
+          ensureLinewiseMove = getEnsurerForLinewiseMove textData,
+            selectedText: "line0\nline1\n", selectionIsReversed: false
+          ensureLinewiseMove 'V j', rows: [0, 1, 2]
+          ensureLinewiseMove 'ctrl-j', rows: [2, 0, 1]
+          ensureLinewiseMove 'ctrl-k', rows: [0, 1, 2]
+        it "[case-3] two line, selection is reversed: keep reversed state", ->
+          ensureLinewiseMove = getEnsurerForLinewiseMove textData,
+            selectedText: "line0\nline1\n", selectionIsReversed: true
+          set cursor: [1, 0]
+          ensureLinewiseMove 'V k', rows: [0, 1, 2]
+          ensureLinewiseMove 'ctrl-j', rows: [2, 0, 1]
+          ensureLinewiseMove 'ctrl-k', rows: [0, 1, 2]
+        it "extends final row when move down", ->
+          ensureLinewiseMove = getEnsurerForLinewiseMove textData,
+            selectedText: "line2\n", selectionIsReversed: false
+          set cursor: [2, 0]
+          ensureLinewiseMove 'V', rows: [0, 1, 2]
+          ensureLinewiseMove 'ctrl-j', text: [
+            "line0"
+            "line1"
+            ""
+            "line2"
+            ""
+          ].join("\n")
+          ensureLinewiseMove 'ctrl-j', text: [
+            "line0"
+            "line1"
+            ""
+            ""
+            "line2"
+            ""
+          ].join("\n")
+        it "support count", ->
+          ensureLinewiseMove = getEnsurerForLinewiseMove textData,
+            selectedText: "line0\n", selectionIsReversed: false
+          ensureLinewiseMove 'V', rows: [0, 1, 2]
+          ensureLinewiseMove '2 ctrl-j', rows: [1, 2, 0]
+          ensureLinewiseMove '2 ctrl-k', rows: [0, 1, 2]
+      describe "overwrite: true", ->
+        beforeEach ->
+          setOverwriteConfig(true)
 
     describe "characterwise", ->
-      beforeEach ->
-        set
-          text: """
-          ooo
-          xxx
-          YYY
-          ZZZ
+      describe "overwrite: false", ->
+        beforeEach ->
+          set
+            text: """
+            ooo
+            xxx
+            YYY
+            ZZZ
 
-          """
-          cursor: [[0, 1], [2, 1]]
-      it "move characterwise, support multiple selection", ->
-        ensure 'v l',
-          mode: ['visual', 'characterwise']
-          selectedTextOrdered: ['oo', 'YY']
-          selectedBufferRange: [
-            [[0, 1], [0, 3]]
-            [[2, 1], [2, 3]]
-          ]
-        ensure 'ctrl-j',
-          selectedTextOrdered: ['oo', 'YY']
-          selectedBufferRange: [
-            [[1, 1], [1, 3]]
-            [[3, 1], [3, 3]]
-          ]
-          text: """
-          oxx
-          xoo
-          YZZ
-          ZYY
+            """
+            cursor: [[0, 1], [2, 1]]
 
-          """
-        ensure 'ctrl-j',
-          selectedTextOrdered: ['oo', 'YY']
-          text: """
-          oxx
-          xZZ
-          Yoo
-          Z__
-           YY
-          """.replace(/_/g, ' ')
+        it "move characterwise, support multiple selection", ->
+          ensure 'v l',
+            mode: ['visual', 'characterwise']
+            selectedTextOrdered: ['oo', 'YY']
+            selectedBufferRange: [
+              [[0, 1], [0, 3]]
+              [[2, 1], [2, 3]]
+            ]
+          ensure 'ctrl-j',
+            selectedTextOrdered: ['oo', 'YY']
+            selectedBufferRange: [
+              [[1, 1], [1, 3]]
+              [[3, 1], [3, 3]]
+            ]
+            text: """
+            oxx
+            xoo
+            YZZ
+            ZYY
 
+            """
+          ensure 'ctrl-j',
+            selectedTextOrdered: ['oo', 'YY']
+            text: """
+            oxx
+            xZZ
+            Yoo
+            Z__
+             YY
+            """.replace(/_/g, ' ')
+      describe "overwrite: true", ->
+        beforeEach ->
+          setOverwriteConfig(true)
 
   describe "move left/right", ->
     textData = null
@@ -234,43 +262,54 @@ describe "vim-mode-plus-move-selected-text", ->
           text: textData.getRaw()
           cursor: [0, 0]
 
-      it "indent/outdent", ->
-        selectedText = "line0\nline1\n"
-        ensure "V j", {selectedText, selectionIsReversed: false}
-        ensure 'ctrl-l',
-          selectedText: "  line0\n  line1\n"
-          selectionIsReversed: false
+      describe "overwrite: false", ->
+        it "indent/outdent", ->
+          selectedText = "line0\nline1\n"
+          ensure "V j", {selectedText, selectionIsReversed: false}
+          ensure 'ctrl-l',
+            selectedText: "  line0\n  line1\n"
+            selectionIsReversed: false
 
-        ensure '2 ctrl-l',
-          selectedText: "      line0\n      line1\n"
-          selectionIsReversed: false
+          ensure '2 ctrl-l',
+            selectedText: "      line0\n      line1\n"
+            selectionIsReversed: false
 
-        ensure '2 ctrl-h',
-          selectedText: "  line0\n  line1\n"
-          selectionIsReversed: false
+          ensure '2 ctrl-h',
+            selectedText: "  line0\n  line1\n"
+            selectionIsReversed: false
 
-        ensure 'ctrl-h',
-          selectedText: "line0\nline1\n"
-          selectionIsReversed: false
+          ensure 'ctrl-h',
+            selectedText: "line0\nline1\n"
+            selectionIsReversed: false
 
-      it "[case-2] indent/outdent", ->
-        text = """
-          line0
+        it "[case-2] indent/outdent", ->
+          text = """
+            line0
+              line1
+                line2
+            line3
+
+            """
+          set {text}
+          ensure "V 3 j", selectedText: text
+          newText = """
+            line0
             line1
-              line2
-          line3
+            line2
+            line3
 
-          """
-        set {text}
-        ensure "V 3 j", selectedText: text
-        newText = """
-          line0
-          line1
-          line2
-          line3
+            """
+          ensure '1 0 ctrl-h', text: newText, selectedText: newText
+      describe "overwrite: true", ->
+        beforeEach ->
+          setOverwriteConfig(true)
 
-          """
-        ensure '1 0 ctrl-h', text: newText, selectedText: newText
+    # TODO
+    describe "characterwise", ->
+      describe "overwrite: false", ->
+      describe "overwrite: true", ->
+        beforeEach ->
+          setOverwriteConfig(true)
 
   describe "duplicate up/down", ->
     beforeEach ->
@@ -284,65 +323,66 @@ describe "vim-mode-plus-move-selected-text", ->
         cursor: [0, 0]
 
     describe "linewise", ->
-      it "duplicate single line", ->
-        ensure 'V', selectedText: 'line0\n'
-        ensure 'cmd-J',
-          selectedBufferRange: rowRange(1, 1)
-          text: 'line0\nline0\nline1\nline2\n'
-      it "duplicate 2 selected line", ->
-        ensure 'V j', selectedText: 'line0\nline1\n'
-        ensure 'cmd-J',
-          selectedBufferRange: rowRange(2, 3)
-          text: """
-          line0
-          line1
-          line0
-          line1
-          line2
+      describe "overwrite: false", ->
+        it "duplicate single line", ->
+          ensure 'V', selectedText: 'line0\n'
+          ensure 'cmd-J',
+            selectedBufferRange: rowRange(1, 1)
+            text: 'line0\nline0\nline1\nline2\n'
+        it "duplicate 2 selected line", ->
+          ensure 'V j', selectedText: 'line0\nline1\n'
+          ensure 'cmd-J',
+            selectedBufferRange: rowRange(2, 3)
+            text: """
+            line0
+            line1
+            line0
+            line1
+            line2
 
-          """
-        ensure 'cmd-K',
-          selectedBufferRange: rowRange(2, 3)
-          text: """
-          line0
-          line1
-          line0
-          line1
-          line0
-          line1
-          line2
+            """
+          ensure 'cmd-K',
+            selectedBufferRange: rowRange(2, 3)
+            text: """
+            line0
+            line1
+            line0
+            line1
+            line0
+            line1
+            line2
 
-          """
-      it "suport count", ->
-        ensure 'V', selectedText: 'line0\n'
-        ensure '2 cmd-J',
-          selectedBufferRange: rowRange(1, 2)
-          text: """
-          line0
-          line0
-          line0
-          line1
-          line2
+            """
+        it "suport count", ->
+          ensure 'V', selectedText: 'line0\n'
+          ensure '2 cmd-J',
+            selectedBufferRange: rowRange(1, 2)
+            text: """
+            line0
+            line0
+            line0
+            line1
+            line2
 
-          """
-        ensure '2 cmd-K',
-          selectedBufferRange: rowRange(1, 4)
-          text: """
-          line0
-          line0
-          line0
-          line0
-          line0
-          line0
-          line0
-          line1
-          line2
+            """
+          ensure '2 cmd-K',
+            selectedBufferRange: rowRange(1, 4)
+            text: """
+            line0
+            line0
+            line0
+            line0
+            line0
+            line0
+            line0
+            line1
+            line2
 
-          """
-
-      describe "overwrite config is true", ->
+            """
+      describe "overwrite: true", ->
         beforeEach ->
-          toggleOverwrite(editorElement)
+          setOverwriteConfig(true)
+
         it "overrite lines down", ->
           ensure 'V', selectedBufferRange: rowRange(0, 0)
           ensure 'cmd-J',
@@ -405,6 +445,13 @@ describe "vim-mode-plus-move-selected-text", ->
 
             """
 
+    # TODO
+    describe "characterwise", ->
+      describe "overwrite: false", ->
+      describe "overwrite: true", ->
+        beforeEach ->
+          setOverwriteConfig(true)
+
   describe "duplicate right/left", ->
     originalText = null
     describe "linewise", ->
@@ -419,27 +466,38 @@ describe "vim-mode-plus-move-selected-text", ->
           text: originalText
           cursor: [0, 0]
 
-      it "duplicate linewise right", ->
-        ensure 'V j j cmd-L',
-          selectedBufferRange: rowRange(0, 2)
-          text: """
-          0 |_0 |_
-          1 midle |_1 midle |_
-          2 very long |_2 very long |_
+      describe "overwrite: false", ->
+        it "duplicate linewise right", ->
+          ensure 'V j j cmd-L',
+            selectedBufferRange: rowRange(0, 2)
+            text: """
+            0 |_0 |_
+            1 midle |_1 midle |_
+            2 very long |_2 very long |_
 
-          """
-      it "count support", ->
-        ensure 'V j j 2 cmd-L',
-          selectedBufferRange: rowRange(0, 2)
-          text: """
-          0 |_0 |_0 |_
-          1 midle |_1 midle |_1 midle |_
-          2 very long |_2 very long |_2 very long |_
+            """
+        it "count support", ->
+          ensure 'V j j 2 cmd-L',
+            selectedBufferRange: rowRange(0, 2)
+            text: """
+            0 |_0 |_0 |_
+            1 midle |_1 midle |_1 midle |_
+            2 very long |_2 very long |_2 very long |_
 
-          """
-      describe "overwrite config is true", ->
+            """
+
+        it "???duplicate linewise left(identical behavior to right)", ->
+          ensure 'V j j cmd-H',
+            selectedBufferRange: rowRange(0, 2)
+            text: """
+            0 |_0 |_
+            1 midle |_1 midle |_
+            2 very long |_2 very long |_
+
+            """
+      describe "overwrite: true", ->
         beforeEach ->
-          toggleOverwrite(editorElement)
+          setOverwriteConfig(true)
 
         it "duplicate linewise right(no behavior diff)", ->
           ensure 'V j j cmd-L',
@@ -455,12 +513,9 @@ describe "vim-mode-plus-move-selected-text", ->
             selectedBufferRange: rowRange(0, 2)
             text: originalText
 
-      it "duplicate linewise left(identical behavior to right)", ->
-        ensure 'V j j cmd-H',
-          selectedBufferRange: rowRange(0, 2)
-          text: """
-          0 |_0 |_
-          1 midle |_1 midle |_
-          2 very long |_2 very long |_
-
-          """
+    # TODO
+    describe "characterwise", ->
+      describe "overwrite: false", ->
+      describe "overwrite: true", ->
+        beforeEach ->
+          setOverwriteConfig(true)

--- a/spec/vim-mode-plus-move-selected-text-spec.coffee
+++ b/spec/vim-mode-plus-move-selected-text-spec.coffee
@@ -129,16 +129,8 @@ describe "vim-mode-plus-move-selected-text", ->
         ensureOverwriteClassForVimStates(allVimState, false)
 
   describe "move up/down", ->
-    textData = null
     beforeEach ->
-      textData = new TextData """
-        line0
-        line1
-        line2\n
-        """
-      set
-        text: textData.getRaw()
-        cursor: [0, 0]
+      set textC: "|line0\nline1\nline2\n"
 
     describe "linewise", ->
       describe "overwrite: false", ->

--- a/spec/vim-mode-plus-move-selected-text-spec.coffee
+++ b/spec/vim-mode-plus-move-selected-text-spec.coffee
@@ -757,15 +757,16 @@ describe "vim-mode-plus-move-selected-text", ->
               [[1, 1], [1, 3]]
               [[2, 1], [2, 3]]
             ]
-          # ensure 'cmd-K',
-          #   mode: ['visual', 'characterwise']
-          #   selectedTextOrdered: ['YY', 'ZZ']
-          #   text: """
-          #   oYYo
-          #   xZZx
-          #   YZZY
-          #   ZZZZ\n
-          #   """
+        xit "duplicate charwise up", ->
+          set
+            textC: """
+            o|ooo
+            xxxx
+            YYYY
+            ZZZZ\n
+            """
+          ensure 'v l cmd-K',
+            mode: ['visual', 'characterwise']
 
   describe "duplicate right/left", ->
     describe "linewise", ->

--- a/spec/vim-mode-plus-move-selected-text-spec.coffee
+++ b/spec/vim-mode-plus-move-selected-text-spec.coffee
@@ -507,126 +507,73 @@ describe "vim-mode-plus-move-selected-text", ->
   describe "duplicate up/down", ->
     beforeEach ->
       set
-        text: """
-        line0
+        textC: """
+        |line0
         line1
         line2
 
         """
-        cursor: [0, 0]
 
     describe "linewise", ->
       describe "overwrite: false", ->
         it "duplicate single line", ->
-          ensure 'V', selectedText: 'line0\n'
+          ensure 'V',
+            selectedBufferRange: rowRange(0, 0)
           ensure 'cmd-J',
             selectedBufferRange: rowRange(1, 1)
             text: 'line0\nline0\nline1\nline2\n'
+
         it "duplicate 2 selected line", ->
-          ensure 'V j', selectedText: 'line0\nline1\n'
+          ensure 'V j',
+            selectedBufferRange: rowRange(0, 1)
           ensure 'cmd-J',
             selectedBufferRange: rowRange(2, 3)
-            text: """
-            line0
-            line1
-            line0
-            line1
-            line2
-
-            """
+            text: "line0\nline1\nline0\nline1\nline2\n"
           ensure 'cmd-K',
             selectedBufferRange: rowRange(2, 3)
-            text: """
-            line0
-            line1
-            line0
-            line1
-            line0
-            line1
-            line2
-
-            """
+            text: "line0\nline1\nline0\nline1\nline0\nline1\nline2\n"
         it "suport count", ->
-          ensure 'V', selectedText: 'line0\n'
+          ensure 'V',
+            selectedBufferRange: rowRange(0, 0)
           ensure '2 cmd-J',
             selectedBufferRange: rowRange(1, 2)
-            text: """
-            line0
-            line0
-            line0
-            line1
-            line2
-
-            """
+            text: "line0\nline0\nline0\nline1\nline2\n"
           ensure '2 cmd-K',
             selectedBufferRange: rowRange(1, 4)
-            text: """
-            line0
-            line0
-            line0
-            line0
-            line0
-            line0
-            line0
-            line1
-            line2
-
-            """
+            text: "line0\nline0\nline0\nline0\nline0\nline0\nline0\nline1\nline2\n"
       describe "overwrite: true", ->
         beforeEach ->
           setOverwriteConfig(true)
 
         it "overrite lines down", ->
-          ensure 'V', selectedBufferRange: rowRange(0, 0)
+          ensure 'V',
+            selectedBufferRange: rowRange(0, 0)
           ensure 'cmd-J',
-            text: """
-            line0
-            line0
-            line2
-
-            """
+            text: "line0\nline0\nline2\n"
           ensure 'cmd-J',
-            text: """
-            line0
-            line0
-            line0
-
-            """
+            text: "line0\nline0\nline0\n"
             selectedBufferRange: rowRange(2, 2)
           ensure '2 cmd-J',
-            text: """
-            line0
-            line0
-            line0
-            line0
-            line0
-
-            """
+            text: "line0\nline0\nline0\nline0\nline0\n"
             selectedBufferRange: rowRange(3, 4)
 
         it "overrite lines up", ->
-          ensure 'j j V', selectedBufferRange: rowRange(2, 2)
+          ensure 'j j V',
+            selectedBufferRange: rowRange(2, 2)
           ensure '2 cmd-K',
             selectedBufferRange: rowRange(0, 1)
-            text: """
-            line2
-            line2
-            line2
-
-            """
+            text: "line2\nline2\nline2\n"
         it "adjust count when duplicate up to stop overwrite when no enough height is available", ->
           set
-            text: """
+            textC: """
             0
             1
             2
-            3
-            4
-
+            |3
+            4\n
             """
-            cursor: [3, 0]
-
-          ensure 'V j', selectedBufferRange: rowRange(3, 4)
+          ensure 'V j',
+            selectedBufferRange: rowRange(3, 4)
           ensure '1 0 cmd-K',
             selectedBufferRange: rowRange(1, 2)
             text: """
@@ -634,8 +581,7 @@ describe "vim-mode-plus-move-selected-text", ->
             3
             4
             3
-            4
-
+            4\n
             """
 
     # TODO

--- a/spec/vim-mode-plus-move-selected-text-spec.coffee
+++ b/spec/vim-mode-plus-move-selected-text-spec.coffee
@@ -584,23 +584,199 @@ describe "vim-mode-plus-move-selected-text", ->
             4\n
             """
 
-    # TODO
     describe "characterwise", ->
       describe "overwrite: false", ->
+        beforeEach ->
+          set
+            textC: """
+            o|ooo
+            xxxx
+            Y|YYY
+            ZZZZ\n
+            """
+        it "duplicate charwise down", ->
+          ensure 'v l',
+            mode: ['visual', 'characterwise']
+            selectedTextOrdered: ['oo', 'YY']
+            text: """
+            oooo
+            xxxx
+            YYYY
+            ZZZZ\n
+            """
+          ensure 'cmd-K',
+            mode: ['visual', 'characterwise']
+            selectedTextOrdered: ['oo', 'YY']
+            text_: """
+            _oo
+            oooo
+            xxxx
+            _YY
+            YYYY
+            ZZZZ\n
+            """
+            selectedBufferRange: [
+              [[0, 1], [0, 3]]
+              [[3, 1], [3, 3]]
+            ]
+          ensure '2 cmd-K',
+            mode: ['visual', 'blockwise']
+            selectedTextOrdered: ['oo', 'oo', 'YY', 'YY']
+            text_: """
+            _oo
+            _oo
+            _oo
+            oooo
+            xxxx
+            _YY
+            _YY
+            _YY
+            YYYY
+            ZZZZ\n
+            """
+            selectedBufferRangeOrdered: [
+              [[0, 1], [0, 3]]
+              [[1, 1], [1, 3]]
+              [[5, 1], [5, 3]]
+              [[6, 1], [6, 3]]
+            ]
+
+        it "duplicate charwise down", ->
+          ensure 'v l',
+            mode: ['visual', 'characterwise']
+            selectedTextOrdered: ['oo', 'YY']
+            text_: """
+            oooo
+            xxxx
+            YYYY
+            ZZZZ\n
+            """
+          ensure 'cmd-J',
+            mode: ['visual', 'characterwise']
+            selectedTextOrdered: ['oo', 'YY']
+            text_: """
+            oooo
+            _oo
+            xxxx
+            YYYY
+            _YY
+            ZZZZ\n
+            """
+            selectedBufferRangeOrdered: [
+              [[1, 1], [1, 3]]
+              [[4, 1], [4, 3]]
+            ]
+          ensure '2 cmd-J',
+            mode: ['visual', 'blockwise']
+            selectedTextOrdered: ['oo', 'oo', 'YY', 'YY']
+            text_: """
+            oooo
+            _oo
+            _oo
+            _oo
+            xxxx
+            YYYY
+            _YY
+            _YY
+            _YY
+            ZZZZ\n
+            """
+            selectedBufferRangeOrdered: [
+              [[2, 1], [2, 3]]
+              [[3, 1], [3, 3]]
+              [[7, 1], [7, 3]]
+              [[8, 1], [8, 3]]
+            ]
+
       describe "overwrite: true", ->
         beforeEach ->
           setOverwriteConfig(true)
+          set
+            textC: """
+            o|ooo
+            xxxx
+            Y|YYY
+            ZZZZ\n
+            """
+
+        it "duplicate charwise down", ->
+          ensure 'v l',
+            mode: ['visual', 'characterwise']
+            selectedTextOrdered: ['oo', 'YY']
+            text: """
+            oooo
+            xxxx
+            YYYY
+            ZZZZ\n
+            """
+          ensure 'cmd-J',
+            mode: ['visual', 'characterwise']
+            selectedTextOrdered: ['oo', 'YY']
+            text: """
+            oooo
+            xoox
+            YYYY
+            ZYYZ\n
+            """
+          ensure '2 cmd-J',
+            mode: ['visual', 'blockwise']
+            selectedTextOrdered: ['oo', 'oo', 'YY', 'YY']
+            text: """
+            oooo
+            xoox
+            YooY
+            ZooZ
+             YY
+             YY
+            """
+        it "duplicate charwise up", ->
+          set
+            cursor: [
+              [2, 1]
+              [3, 1]
+            ]
+          ensure 'v l',
+            mode: ['visual', 'characterwise']
+            selectedTextOrdered: ['YY', 'ZZ']
+            text: """
+            oooo
+            xxxx
+            YYYY
+            ZZZZ\n
+            """
+          ensure 'cmd-K',
+            mode: ['visual', 'characterwise']
+            selectedTextOrdered: ['YY', 'ZZ']
+            text: """
+            oooo
+            xYYx
+            YZZY
+            ZZZZ\n
+            """
+            selectedBufferRangeOrdered: [
+              [[1, 1], [1, 3]]
+              [[2, 1], [2, 3]]
+            ]
+          # ensure 'cmd-K',
+          #   mode: ['visual', 'characterwise']
+          #   selectedTextOrdered: ['YY', 'ZZ']
+          #   text: """
+          #   oYYo
+          #   xZZx
+          #   YZZY
+          #   ZZZZ\n
+          #   """
 
   describe "duplicate right/left", ->
-    originalText = null
     describe "linewise", ->
+      originalText = null
       beforeEach ->
         originalText = """
-        0 |_
-        1 midle |_
-        2 very long |_
+          0 |_
+          1 midle |_
+          2 very long |_
 
-        """
+          """
         set
           text: originalText
           cursor: [0, 0]
@@ -625,7 +801,7 @@ describe "vim-mode-plus-move-selected-text", ->
 
             """
 
-        it "???duplicate linewise left(identical behavior to right)", ->
+        it "duplicate linewise left(identical behavior to right)", ->
           ensure 'V j j cmd-H',
             selectedBufferRange: rowRange(0, 2)
             text: """
@@ -634,11 +810,20 @@ describe "vim-mode-plus-move-selected-text", ->
             2 very long |_2 very long |_
 
             """
+        it "duplicate linewise left with count(identical behavior to right)", ->
+          ensure 'V j j 2 cmd-H',
+            selectedBufferRange: rowRange(0, 2)
+            text: """
+            0 |_0 |_0 |_
+            1 midle |_1 midle |_1 midle |_
+            2 very long |_2 very long |_2 very long |_
+
+            """
       describe "overwrite: true", ->
         beforeEach ->
           setOverwriteConfig(true)
 
-        it "duplicate linewise right(no behavior diff)", ->
+        it "duplicate linewise right(no behavior diff with overwrite=false)", ->
           ensure 'V j j cmd-L',
             selectedBufferRange: rowRange(0, 2)
             text: """
@@ -647,14 +832,155 @@ describe "vim-mode-plus-move-selected-text", ->
             2 very long |_2 very long |_
 
             """
+        it "duplicate linewise right(no behavior diff with overwrite=false)", ->
+          ensure 'V j j 2 cmd-L',
+            selectedBufferRange: rowRange(0, 2)
+            text: """
+            0 |_0 |_0 |_
+            1 midle |_1 midle |_1 midle |_
+            2 very long |_2 very long |_2 very long |_
+
+            """
         it "duplicate linewise left do nothing", ->
           ensure 'V j j cmd-H',
             selectedBufferRange: rowRange(0, 2)
             text: originalText
+        it "duplicate linewise left with count do nothing", ->
+          ensure 'V j j 2 cmd-H',
+            selectedBufferRange: rowRange(0, 2)
+            text: originalText
 
-    # TODO
     describe "characterwise", ->
       describe "overwrite: false", ->
+        beforeEach ->
+          set
+            textC: """
+            o|oo
+            xxx
+            Y|YY
+            ZZZ\n
+            """
+        it "duplicate charwise", ->
+          ensureDuplicate = getEnsureWithOptions(mode: ['visual', 'characterwise'], selectedTextOrdered: ['oo', 'YY'])
+          ensureDuplicate 'v l',
+            text: """
+            ooo
+            xxx
+            YYY
+            ZZZ\n
+            """
+          ensureDuplicate 'cmd-L',
+            text: """
+            ooooo
+            xxx
+            YYYYY
+            ZZZ\n
+            """
+          ensureDuplicate '2 cmd-L',
+            selectedTextOrdered: ['oooo', 'YYYY']
+            text: """
+            ooooooooo
+            xxx
+            YYYYYYYYY
+            ZZZ\n
+            """
+          ensureDuplicate 'ctrl-j', # "move"
+            selectedTextOrdered: ['oooo', 'YYYY']
+            text_: """
+            ooooo____
+            xxx  oooo
+            YYYYY____
+            ZZZ__YYYY\n
+            """
+          ensureDuplicate 'cmd-H',
+            selectedTextOrdered: ['oooo', 'YYYY']
+            selectedBufferRange: [
+              [[1, 5], [1, 9]]
+              [[3, 5], [3, 9]]
+            ]
+            text_: """
+            ooooo____
+            xxx__oooooooo
+            YYYYY____
+            ZZZ__YYYYYYYY\n
+            """
+          ensureDuplicate '2 cmd-H',
+            selectedTextOrdered: ['oooooooo', 'YYYYYYYY']
+            selectedBufferRange: [
+              [[1, 5], [1, 13]]
+              [[3, 5], [3, 13]]
+            ]
+            text_: """
+            ooooo____
+            xxx__oooooooooooooooo
+            YYYYY____
+            ZZZ__YYYYYYYYYYYYYYYY\n
+            """
+
       describe "overwrite: true", ->
         beforeEach ->
           setOverwriteConfig(true)
+          set
+            textC: """
+            o|xYZ@
+            oxYZ@
+            o|xYZ@
+            oxYZ@\n
+            """
+
+        it "duplicate charwise", ->
+          ensureDuplicate = getEnsureWithOptions(mode: ['visual', 'characterwise'], selectedTextOrdered: ['xY', 'xY'])
+          ensureDuplicate 'v l',
+            text: """
+            oxYZ@
+            oxYZ@
+            oxYZ@
+            oxYZ@\n
+            """
+          ensureDuplicate 'cmd-L',
+            text: """
+            oxYxY
+            oxYZ@
+            oxYxY
+            oxYZ@\n
+            """
+            selectedBufferRange: [
+              [[0, 3], [0, 5]]
+              [[2, 3], [2, 5]]
+            ]
+          ensureDuplicate '2 cmd-L',
+            selectedTextOrdered: ['xYxY', 'xYxY']
+            text: """
+            oxYxYxYxY
+            oxYZ@
+            oxYxYxYxY
+            oxYZ@\n
+            """
+            selectedBufferRange: [
+              [[0, 5], [0, 9]]
+              [[2, 5], [2, 9]]
+            ]
+          ensureDuplicate 'ctrl-j', # "move"
+            selectedTextOrdered: ['xYxY', 'xYxY']
+            text_: """
+            oxYxY____
+            oxYZ@xYxY
+            oxYxY____
+            oxYZ@xYxY\n
+            """
+            selectedBufferRange: [
+              [[1, 5], [1, 9]]
+              [[3, 5], [3, 9]]
+            ]
+          ensureDuplicate 'cmd-H',
+            selectedTextOrdered: ['xYxY', 'xYxY']
+            text_: """
+            oxYxY____
+            oxYxYxYxY
+            oxYxY____
+            oxYxYxYxY\n
+            """
+            selectedBufferRange: [
+              [[1, 1], [1, 5]]
+              [[3, 1], [3, 5]]
+            ]


### PR DESCRIPTION

## Move

- `overwrite`: false
  - `linewise`:
    - rotateRows in direction to move
  - `characterwise`:
    - If multiRowSelection, behave as linewise
    - For single selection
      - swap selected charwise-block with charwise-block in direction to move
  - `blockwise`
- `overwrite`: true
  - `linewise`: rotateRows
    - manage overwritten area
  - `characterwise`:
    - If multiRowSelection, behave as linewise
    - For single selection
      - manage overwritten area
  - `blockwise`

## Duplicate

- `overwrite`: false
  - `linewise`
  - `characterwise`
  - `blockwise`
- `overwrite`: true
  - `linewise`
  - `characterwise`
  - `blockwise`
